### PR TITLE
[VW-81353]  INTERNAL - Allstate - Rochelle - Nutanix integration UI d…

### DIFF
--- a/internal/nutanix/exporter_health.go
+++ b/internal/nutanix/exporter_health.go
@@ -265,3 +265,69 @@ func ClearLastError(section string) {
 	h.lastError = ""
 	h.mu.Unlock()
 }
+
+// AllSectionsHealthCollector collects health metrics for ALL configured sections
+// This is used when health=true is called without a specific section parameter
+type AllSectionsHealthCollector struct{}
+
+func NewAllSectionsHealthCollector() *AllSectionsHealthCollector {
+	return &AllSectionsHealthCollector{}
+}
+
+func (c *AllSectionsHealthCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descErrConnTimeout
+	ch <- descErrCollectionStillRunning
+	ch <- descErrException
+	ch <- descErrDNSFailure
+	ch <- descSuccessDeviceCmd
+	ch <- descTotalSuccessCmdExecDurationUS
+	ch <- descTotalSuccessCollectionDurationUS
+	ch <- descFailureDeviceCmd
+	ch <- descTotalFailureCmdExecDurationUS
+	ch <- descTotalFailureCollectionDurationUS
+	ch <- descTotalPollCycles
+	ch <- descSuccessfulPCCallNoErrors
+	ch <- descFailedCollections
+	ch <- descCollErrors
+}
+
+func (c *AllSectionsHealthCollector) Collect(ch chan<- prometheus.Metric) {
+	healthMu.RLock()
+	// Copy sections to avoid holding lock during metric emission
+	sections := make([]string, 0, len(healthBySection))
+	for section := range healthBySection {
+		sections = append(sections, section)
+	}
+	healthMu.RUnlock()
+
+	// Emit health metrics for each section
+	for _, section := range sections {
+		h := getHealth(section)
+		h.mu.RLock()
+
+		// Use section as cluster_uuid and uuid for consistency
+		clusterUUID := section
+		uuid := section
+
+		ch <- prometheus.MustNewConstMetric(descErrConnTimeout, prometheus.CounterValue, float64(h.errConnTimeout), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descErrCollectionStillRunning, prometheus.CounterValue, float64(h.errCollectionStillRunning), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descErrException, prometheus.CounterValue, float64(h.errException), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descErrDNSFailure, prometheus.CounterValue, float64(h.errDNSFailure), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descSuccessDeviceCmd, prometheus.CounterValue, float64(h.successDeviceCmd), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descTotalSuccessCmdExecDurationUS, prometheus.CounterValue, float64(h.totalSuccessCmdExecDurationUS), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descTotalSuccessCollectionDurationUS, prometheus.CounterValue, float64(h.totalSuccessCollectionDurationUS), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descFailureDeviceCmd, prometheus.CounterValue, float64(h.failureDeviceCmd), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descTotalFailureCmdExecDurationUS, prometheus.CounterValue, float64(h.totalFailureCmdExecDurationUS), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descTotalFailureCollectionDurationUS, prometheus.CounterValue, float64(h.totalFailureCollectionDurationUS), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descTotalPollCycles, prometheus.CounterValue, float64(h.totalPollCycles), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descSuccessfulPCCallNoErrors, prometheus.CounterValue, float64(h.successfulPCCallNoErrors), clusterUUID, uuid, section)
+		ch <- prometheus.MustNewConstMetric(descFailedCollections, prometheus.CounterValue, float64(h.failedCollections), clusterUUID, uuid, section)
+
+		// Emit collection error metric with detailed error message if present
+		if h.lastError != "" {
+			ch <- prometheus.MustNewConstMetric(descCollErrors, prometheus.GaugeValue, 1, clusterUUID, uuid, section, h.lastError, "nutanix")
+		}
+
+		h.mu.RUnlock()
+	}
+}

--- a/internal/nutanix/exporter_health.go
+++ b/internal/nutanix/exporter_health.go
@@ -33,6 +33,9 @@ type ExporterHealth struct {
 	// Track command durations at collection start to calculate incremental duration per collection
 	cmdExecDurationAtCollectionStart uint64 // Success command duration when collection started
 	failureCmdExecDurationAtStart    uint64 // Failure command duration when collection started
+
+	// Detailed error message for CAPI reporting
+	lastError string
 }
 
 // healthBySection keeps one health state per configuration/section
@@ -67,6 +70,8 @@ var (
 	descTotalPollCycles                  = prometheus.NewDesc("nutanix_exporter_TotalPollCycles_C", "Exporter: total poll cycles (cumulative counter, increments per completed collection)", []string{"cluster_uuid", "uuid", "section"}, nil)
 	descSuccessfulPCCallNoErrors         = prometheus.NewDesc("nutanix_exporter_SuccessfulPCCallNoErrors_C", "Exporter: successful poll cycles with no errors", []string{"cluster_uuid", "uuid", "section"}, nil)
 	descFailedCollections                = prometheus.NewDesc("nutanix_exporter_FailedCollections_C", "Exporter: failed collection attempts", []string{"cluster_uuid", "uuid", "section"}, nil)
+	// Collection error metric with detailed error message for CAPI
+	descCollErrors = prometheus.NewDesc("nutanix_exporter_coll_errors", "Exporter: collection errors with detailed message", []string{"cluster_uuid", "uuid", "section", "error_msg", "collector"}, nil)
 )
 
 // ExporterHealthCollector exposes ExporterHealth as Prometheus metrics
@@ -90,6 +95,7 @@ func (c *ExporterHealthCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descTotalPollCycles
 	ch <- descSuccessfulPCCallNoErrors
 	ch <- descFailedCollections
+	ch <- descCollErrors
 }
 
 func (c *ExporterHealthCollector) Collect(ch chan<- prometheus.Metric) {
@@ -111,6 +117,11 @@ func (c *ExporterHealthCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(descTotalPollCycles, prometheus.CounterValue, float64(h.totalPollCycles), c.clusterUUID, c.uuid, c.section)
 	ch <- prometheus.MustNewConstMetric(descSuccessfulPCCallNoErrors, prometheus.CounterValue, float64(h.successfulPCCallNoErrors), c.clusterUUID, c.uuid, c.section)
 	ch <- prometheus.MustNewConstMetric(descFailedCollections, prometheus.CounterValue, float64(h.failedCollections), c.clusterUUID, c.uuid, c.section)
+
+	// Emit collection error metric with detailed error message if present
+	if h.lastError != "" {
+		ch <- prometheus.MustNewConstMetric(descCollErrors, prometheus.GaugeValue, 1, c.clusterUUID, c.uuid, c.section, h.lastError, "nutanix")
+	}
 }
 
 // StartHealthTicker is deprecated - no longer used.
@@ -227,5 +238,30 @@ func IncException(section string) {
 	h := getHealth(section)
 	h.mu.Lock()
 	h.errException++
+	h.mu.Unlock()
+}
+
+// SetLastError stores a detailed error message for the section
+// This will be emitted as a metric label for CAPI to consume
+func SetLastError(section string, errMsg string) {
+	h := getHealth(section)
+	h.mu.Lock()
+	h.lastError = errMsg
+	h.mu.Unlock()
+}
+
+// GetLastError retrieves the last error message for the section
+func GetLastError(section string) string {
+	h := getHealth(section)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.lastError
+}
+
+// ClearLastError clears the last error message for the section
+func ClearLastError(section string) {
+	h := getHealth(section)
+	h.mu.Lock()
+	h.lastError = ""
 	h.mu.Unlock()
 }

--- a/internal/nutanix/exporter_health_test.go
+++ b/internal/nutanix/exporter_health_test.go
@@ -27,10 +27,10 @@ func TestExporterHealthCollector(t *testing.T) {
 		descs = append(descs, desc)
 	}
 
-	// Should have 13 descriptors (all health metrics)
-	assert.Len(t, descs, 13)
+	// Should have 14 descriptors (all health metrics including coll_errors)
+	assert.Len(t, descs, 14)
 
-	// Test Collect with initial values
+	// Test Collect with initial values (no error set, so 13 metrics)
 	metricCh := make(chan prometheus.Metric, 20)
 	collector.Collect(metricCh)
 	close(metricCh)
@@ -40,7 +40,7 @@ func TestExporterHealthCollector(t *testing.T) {
 		metrics = append(metrics, metric)
 	}
 
-	// Should have 13 metrics
+	// Should have 13 metrics (coll_errors only emitted when lastError is set)
 	assert.Len(t, metrics, 13)
 
 	// Verify all metrics have correct descriptors
@@ -413,4 +413,76 @@ func TestGetHealth(t *testing.T) {
 	// Test that instances are valid
 	assert.NotNil(t, h1)
 	assert.NotNil(t, h3)
+}
+
+func TestSetLastError(t *testing.T) {
+	// Reset global state
+	healthMu.Lock()
+	healthBySection = make(map[string]*ExporterHealth)
+	healthMu.Unlock()
+
+	section := "test-error-section"
+
+	// Initially no error
+	err := GetLastError(section)
+	assert.Empty(t, err)
+
+	// Set an error
+	SetLastError(section, "Authentication failed (HTTP 401)")
+	err = GetLastError(section)
+	assert.Equal(t, "Authentication failed (HTTP 401)", err)
+
+	// Clear the error
+	ClearLastError(section)
+	err = GetLastError(section)
+	assert.Empty(t, err)
+}
+
+func TestCollErrorMetricEmission(t *testing.T) {
+	// Reset global state
+	healthMu.Lock()
+	healthBySection = make(map[string]*ExporterHealth)
+	healthMu.Unlock()
+
+	section := "test-coll-error-section"
+	collector := NewExporterHealthCollector(section, "test-uuid", "test-cluster-uuid")
+
+	// Without error - should have 13 metrics
+	metricCh := make(chan prometheus.Metric, 20)
+	collector.Collect(metricCh)
+	close(metricCh)
+
+	count := 0
+	for range metricCh {
+		count++
+	}
+	assert.Equal(t, 13, count, "Without error should have 13 metrics")
+
+	// Set an error
+	SetLastError(section, "Test error message")
+
+	// With error - should have 14 metrics (including coll_errors)
+	metricCh2 := make(chan prometheus.Metric, 20)
+	collector.Collect(metricCh2)
+	close(metricCh2)
+
+	count2 := 0
+	for range metricCh2 {
+		count2++
+	}
+	assert.Equal(t, 14, count2, "With error should have 14 metrics including coll_errors")
+
+	// Clear error
+	ClearLastError(section)
+
+	// After clearing - back to 13 metrics
+	metricCh3 := make(chan prometheus.Metric, 20)
+	collector.Collect(metricCh3)
+	close(metricCh3)
+
+	count3 := 0
+	for range metricCh3 {
+		count3++
+	}
+	assert.Equal(t, 13, count3, "After clearing error should have 13 metrics")
 }

--- a/internal/nutanix/nutanix.go
+++ b/internal/nutanix/nutanix.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -39,6 +40,8 @@ type Nutanix struct {
 	username            string
 	password            string
 	maxParallelRequests int
+	httpClient          *http.Client
+	httpClientOnce      sync.Once
 }
 
 func (g *Nutanix) makeV1Request(reqType string, action string, params url.Values) (*http.Response, error) {
@@ -49,6 +52,24 @@ func (g *Nutanix) makeV2Request(reqType string, action string, params url.Values
 	return g.makeRequestWithParams(PRISM_API_PATH_VERSION_V2, reqType, action, RequestParams{params: params})
 }
 
+// getHTTPClient returns a shared HTTP client with connection pooling
+func (g *Nutanix) getHTTPClient() *http.Client {
+	g.httpClientOnce.Do(func() {
+		tr := &http.Transport{
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+			MaxIdleConns:        100,              // Maximum idle connections across all hosts
+			MaxIdleConnsPerHost: 10,               // Maximum idle connections per host
+			IdleConnTimeout:     90 * time.Second, // Close idle connections after 90s
+			DisableKeepAlives:   false,            // Enable HTTP keep-alive
+		}
+		g.httpClient = &http.Client{
+			Transport: tr,
+			Timeout:   HTTP_TIMEOUT,
+		}
+	})
+	return g.httpClient
+}
+
 func (g *Nutanix) makeRequestWithParams(versionPath, reqType, action string, p RequestParams) (*http.Response, error) {
 	_url := strings.Trim(g.url, "/")
 	_url += "/PrismGateway/services/rest/" + versionPath
@@ -56,11 +77,8 @@ func (g *Nutanix) makeRequestWithParams(versionPath, reqType, action string, p R
 
 	log.Debugf("URL: %s", _url)
 
-	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	var netClient = http.Client{
-		Transport: tr,
-		Timeout:   HTTP_TIMEOUT,
-	}
+	// Use shared HTTP client with connection pooling
+	netClient := g.getHTTPClient()
 
 	body := p.body
 
@@ -81,13 +99,22 @@ func (g *Nutanix) makeRequestWithParams(versionPath, reqType, action string, p R
 	resp, err := netClient.Do(req)
 	if err != nil {
 		log.Errorf("failed to execute request; error=%v\n", err)
-		// heuristics for health
+		// heuristics for health and detailed error messages
 		if strings.Contains(strings.ToLower(err.Error()), "timeout") {
 			IncConnTimeout(g.url)
+			SetLastError(g.url, fmt.Sprintf("Connection timeout - device '%s' not responding. Check network connectivity and ensure the Prism Central is accessible.", g.url))
 		} else if strings.Contains(strings.ToLower(err.Error()), "no such host") {
 			IncDNSFailure(g.url)
+			SetLastError(g.url, fmt.Sprintf("DNS lookup failed - unable to resolve hostname for '%s'. Verify the endpoint URL is correct.", g.url))
+		} else if strings.Contains(strings.ToLower(err.Error()), "connection refused") {
+			IncException(g.url)
+			SetLastError(g.url, fmt.Sprintf("Connection refused by '%s'. Verify the Prism Central service is running and the port is correct.", g.url))
+		} else if strings.Contains(strings.ToLower(err.Error()), "certificate") || strings.Contains(strings.ToLower(err.Error()), "tls") {
+			IncException(g.url)
+			SetLastError(g.url, fmt.Sprintf("TLS/Certificate error connecting to '%s'. Check certificate configuration.", g.url))
 		} else {
 			IncException(g.url)
+			SetLastError(g.url, fmt.Sprintf("Failed to connect to '%s': %s", g.url, err.Error()))
 		}
 		MarkCmdFailure(g.url, time.Since(start))
 		return nil, err
@@ -95,10 +122,27 @@ func (g *Nutanix) makeRequestWithParams(versionPath, reqType, action string, p R
 
 	if resp.StatusCode >= 400 {
 		log.Errorf("error status from server; status=%v code=%v\n", resp.Status, resp.StatusCode)
+		// Set detailed error message based on HTTP status code
+		switch resp.StatusCode {
+		case 401:
+			SetLastError(g.url, fmt.Sprintf("Authentication failed (HTTP 401) - invalid username or password for endpoint '%s'.", g.url))
+		case 403:
+			SetLastError(g.url, fmt.Sprintf("Access forbidden (HTTP 403) - insufficient permissions for endpoint '%s'. Check user role and permissions.", g.url))
+		case 404:
+			SetLastError(g.url, fmt.Sprintf("Resource not found (HTTP 404) - API endpoint not available at '%s'. Verify API version compatibility.", g.url))
+		case 429:
+			SetLastError(g.url, fmt.Sprintf("Rate limited (HTTP 429) by endpoint '%s'. Too many requests - will retry.", g.url))
+		case 500, 502, 503, 504:
+			SetLastError(g.url, fmt.Sprintf("Server error (HTTP %d) from '%s'. The Prism Central may be overloaded or experiencing issues.", resp.StatusCode, g.url))
+		default:
+			SetLastError(g.url, fmt.Sprintf("HTTP error %d from '%s': %s", resp.StatusCode, g.url, resp.Status))
+		}
 		MarkCmdFailure(g.url, time.Since(start))
 		return nil, fmt.Errorf("error status received")
 	}
 
+	// Clear any previous error on success
+	ClearLastError(g.url)
 	MarkCmdSuccess(g.url, time.Since(start))
 	return resp, nil
 }

--- a/main.go
+++ b/main.go
@@ -101,47 +101,9 @@ func main() {
 			// If health=true with no section, collect health metrics for all sections only
 			if healthOnly {
 				log.Infof("health=true with no section specified, collecting health metrics for all configured sections")
-				// Iterate through all sections in config
-				for sectionName, conf := range config {
-					healthSectionKey := conf.Host
-					if len(healthSectionKey) == 0 {
-						healthSectionKey = sectionName // Fallback to section name if host is empty
-					}
 
-					// Get cluster UUID for this section (from cache if available)
-					healthUUID := "exporter-health"
-					clusterUUID := "exporter-health"
-
-					// Try to get from cache first
-					clusterUUIDCacheMu.RLock()
-					cachedUUID, found := clusterUUIDCache[sectionName]
-					clusterUUIDCacheMu.RUnlock()
-
-					if found {
-						healthUUID = cachedUUID
-						clusterUUID = cachedUUID
-					} else if len(conf.Host) > 0 {
-						// Try to fetch cluster UUID if host is configured
-						// Use a temporary API client just for UUID lookup
-						tempAPI := nutanix.NewNutanix(conf.Host, conf.Username, conf.Password, conf.MaxParallelRequests)
-						clusterUUIDValue, err := tempAPI.GetClusterUUID()
-						if err != nil {
-							log.Debugf("Failed to get cluster UUID for section %s: %v, using fallback", sectionName, err)
-							healthUUID = sectionName
-							clusterUUID = sectionName
-						} else {
-							healthUUID = clusterUUIDValue
-							clusterUUID = clusterUUIDValue
-							// Cache it for future requests
-							clusterUUIDCacheMu.Lock()
-							clusterUUIDCache[sectionName] = clusterUUIDValue
-							clusterUUIDCacheMu.Unlock()
-						}
-					}
-
-					// Register health collector for this section
-					registry.MustRegister(nutanix.NewExporterHealthCollector(healthSectionKey, healthUUID, clusterUUID))
-				}
+				// Use AllSectionsHealthCollector to collect health metrics for ALL sections in one call
+				registry.MustRegister(nutanix.NewAllSectionsHealthCollector())
 
 				// For all-sections health mode, only return health metrics (not regular metrics)
 				h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})


### PR DESCRIPTION

---

## Error Scenarios Supported

Both collectors now provide detailed, actionable error messages for:

- **Connection Timeout**: "Connection timeout - device '%s' not responding..."
- **DNS Failure**: "DNS lookup failed - unable to resolve hostname for '%s'..."
- **Connection Refused**: "Connection refused by '%s'..."
- **TLS/Certificate Error**: "TLS/Certificate error connecting to '%s'..."
- **HTTP 401 (Auth Failed)**: "Authentication failed (HTTP 401) - invalid username or password..."
- **HTTP 403 (Forbidden)**: "Access forbidden (HTTP 403) - insufficient permissions..."
- **HTTP 404 (Not Found)**: "Resource not found (HTTP 404) - API endpoint not available..."
- **HTTP 429 (Rate Limited)**: "Rate limited (HTTP 429) - too many requests..."
- **HTTP 5xx (Server Error)**: "Server error (HTTP %d) - Prism Central overloaded or experiencing issues..."

---

## Implementation Details

### Files Modified

**Nutanix Exporter:**
- `nutanix-exporter/internal/nutanix/exporter_health.go`
  - Added `lastError` field to `ExporterHealth` struct
  - Added `SetLastError()`, `GetLastError()`, `ClearLastError()` functions
  - Updated `Collect()` to emit `nutanix_exporter_coll_errors` metric
  
- `nutanix-exporter/internal/nutanix/nutanix.go`
  - Enhanced `makeRequestWithParams()` with detailed error classification
  - Calls `SetLastError()` with specific error messages for each scenario
  - Calls `ClearLastError()` on successful requests

- `nutanix-exporter/internal/nutanix/exporter_health_test.go`
  - Added tests for error storage and metric emission

**OTEL Receiver:**
- `translator-otel/restapi-receiver-common/health_metrics.go`
  - Added `errorBySection` map for thread-safe error storage
  - Added `SetLastError()`, `GetLastError()`, `ClearLastError()` functions
  - Modified `CreateHealthMetricsAsOTLP()` to emit error metric

- `translator-otel/translator/intervalcache/actions.go`
  - Added `AddCollectionError()` helper method for direct error reporting

**Common Configuration:**
- `translator-nutanix/rules.yaml`
  - Added `recordId: nutanix_exporter_coll_errors` rule
  - Added `recordId: restapi_receiver_coll_errors` rule
  - Both rules extract error messages via CEL expressions and route to `collect_error` action

---

