### PR TITLE
Fixed cluster uuid being populated as section url

### DIFF
--- a/internal/nutanix/exporter_health.go
+++ b/internal/nutanix/exporter_health.go
@@ -36,6 +36,10 @@ type ExporterHealth struct {
 
 	// Detailed error message for CAPI reporting
 	lastError string
+
+	// Actual Nutanix cluster UUID (retrieved from API)
+	// This is used for proper metric labeling instead of the section URL
+	clusterUUID string
 }
 
 // healthBySection keeps one health state per configuration/section
@@ -266,6 +270,24 @@ func ClearLastError(section string) {
 	h.mu.Unlock()
 }
 
+// SetClusterUUID stores the actual Nutanix cluster UUID for the section
+// This should be called after successfully retrieving the cluster UUID from the API
+func SetClusterUUID(section string, clusterUUID string) {
+	h := getHealth(section)
+	h.mu.Lock()
+	h.clusterUUID = clusterUUID
+	h.mu.Unlock()
+}
+
+// GetStoredClusterUUID retrieves the stored cluster UUID for the section
+// Returns empty string if not set
+func GetStoredClusterUUID(section string) string {
+	h := getHealth(section)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.clusterUUID
+}
+
 // AllSectionsHealthCollector collects health metrics for ALL configured sections
 // This is used when health=true is called without a specific section parameter
 type AllSectionsHealthCollector struct{}
@@ -305,9 +327,12 @@ func (c *AllSectionsHealthCollector) Collect(ch chan<- prometheus.Metric) {
 		h := getHealth(section)
 		h.mu.RLock()
 
-		// Use section as cluster_uuid and uuid for consistency
-		clusterUUID := section
-		uuid := section
+		// Use stored cluster UUID if available, otherwise fall back to section
+		clusterUUID := h.clusterUUID
+		if clusterUUID == "" {
+			clusterUUID = section // Fallback to section URL if cluster UUID not yet retrieved
+		}
+		uuid := clusterUUID // Use same value for uuid label
 
 		ch <- prometheus.MustNewConstMetric(descErrConnTimeout, prometheus.CounterValue, float64(h.errConnTimeout), clusterUUID, uuid, section)
 		ch <- prometheus.MustNewConstMetric(descErrCollectionStillRunning, prometheus.CounterValue, float64(h.errCollectionStillRunning), clusterUUID, uuid, section)

--- a/main.go
+++ b/main.go
@@ -194,6 +194,8 @@ func main() {
 					healthUUID = cachedUUID
 					clusterUUID = cachedUUID
 					log.Debugf("Using cached cluster UUID for section %s: %s", section, healthUUID)
+					// Also store in health tracking for AllSectionsHealthCollector
+					nutanix.SetClusterUUID(healthSectionKey, cachedUUID)
 				} else if len(conf.Host) > 0 {
 					// Create Nutanix API client and try to get cluster UUID
 					log.Infof("Host: %s", *nutanixURL)
@@ -211,6 +213,8 @@ func main() {
 						clusterUUIDCache[section] = clusterUUIDValue
 						clusterUUIDCacheMu.Unlock()
 						log.Infof("Successfully fetched and cached cluster UUID for section %s: %s", section, healthUUID)
+						// Also store in health tracking for AllSectionsHealthCollector
+						nutanix.SetClusterUUID(healthSectionKey, clusterUUIDValue)
 					}
 				}
 			} else {
@@ -238,6 +242,33 @@ func main() {
 				return
 			}
 			nutanixAPI = nutanix.NewNutanix(*nutanixURL, *nutanixUser, *nutanixPassword, maxParallelReq)
+		}
+
+		// Fetch and store cluster UUID for health metrics during regular collection
+		// This ensures AllSectionsHealthCollector has the correct UUID even without health=true requests
+		if ok {
+			// Check if we already have the cluster UUID cached
+			clusterUUIDCacheMu.RLock()
+			cachedUUID, found := clusterUUIDCache[section]
+			clusterUUIDCacheMu.RUnlock()
+
+			if found {
+				// Use cached UUID and ensure it's stored in health tracking
+				nutanix.SetClusterUUID(healthSectionKey, cachedUUID)
+			} else {
+				// Try to fetch cluster UUID
+				clusterUUIDValue, err := nutanixAPI.GetClusterUUID()
+				if err != nil {
+					log.Debugf("Failed to get cluster UUID during regular collection: %v", err)
+				} else {
+					// Cache it and store in health tracking
+					clusterUUIDCacheMu.Lock()
+					clusterUUIDCache[section] = clusterUUIDValue
+					clusterUUIDCacheMu.Unlock()
+					nutanix.SetClusterUUID(healthSectionKey, clusterUUIDValue)
+					log.Debugf("Fetched and cached cluster UUID during regular collection: %s", clusterUUIDValue)
+				}
+			}
 		}
 
 		// Poll cycles are tracked automatically when MarkCollectionEnd is called


### PR DESCRIPTION
Summary
The fix involved:

Added [clusterUUID] field to ExporterHealth struct in [exporter_health.go]

Added [SetClusterUUID()] functions to store/retrieve the actual Nutanix cluster UUID

Updated AllSectionsHealthCollector.Collect() to use the stored cluster UUID if available, falling back to section URL only if not yet retrieved

Updated [main.go]
During health-only requests (when cluster UUID is fetched or retrieved from cache)
During regular metric collection (to ensure health metrics have correct UUID even without explicit health=true requests)